### PR TITLE
Add zipline challenge flag

### DIFF
--- a/Ahorn/entities/zipline.jl
+++ b/Ahorn/entities/zipline.jl
@@ -2,7 +2,7 @@ module IsaGrabBagZipline
 
 using ..Ahorn, Maple
 
-@mapdef Entity "isaBag/zipline" Zipline(x::Integer, y::Integer, nodes::Array{Tuple{Integer, Integer}, 1}=Tuple{Integer, Integer}[], usesStamina::Bool=true, flag::String="")
+@mapdef Entity "isaBag/zipline" Zipline(x::Integer, y::Integer, nodes::Array{Tuple{Integer, Integer}, 1}=Tuple{Integer, Integer}[], usesStamina::Bool=true)
 
 const placements = Ahorn.PlacementDict(
 	"Zipline (IsaGrabBag)" => Ahorn.EntityPlacement(

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -21,7 +21,6 @@ placements.entities.isaBag/waterBoost.tooltips.boostEnabled=Whether to enable wa
 
 # Zipline
 placements.entities.isaBag/zipline.tooltips.usesStamina=Whether riding the zipline or jumping from it should consume stamina.
-placements.entities.isaBag/zipline.tooltips.flag=The flag to enable when the player uses the zipline. Leave empty if you don't want any flag to be set.
 
 # Core Wind Trigger
 placements.triggers.isaBag/coreWindTrigger.tooltips.patternHot=The wind pattern to use when the core mode is Hot.

--- a/Code/Module.cs
+++ b/Code/Module.cs
@@ -31,9 +31,6 @@ namespace Celeste.Mod.IsaGrabBag {
             }
         }
 
-        public static int ZipLineState { get; private set; }
-        public static int ArrowBlockState { get; private set; }
-
         public override Type SessionType => typeof(IsaSession);
         public static IsaSession Session => (IsaSession)Instance._Session;
 
@@ -48,6 +45,7 @@ namespace Celeste.Mod.IsaGrabBag {
             DreamSpinnerRenderer.Load();
             ForceVariants.Load();
             RewindCrystal.Load();
+            ZipLine.Load();
 
             Everest.Events.Level.OnTransitionTo += Level_OnTransitionTo;
             Everest.Events.Level.OnEnter += Level_OnEnter;
@@ -55,9 +53,6 @@ namespace Celeste.Mod.IsaGrabBag {
             Everest.Events.Level.OnLoadEntity += Level_OnLoadEntity;
             Everest.Events.Player.OnSpawn += Player_OnSpawn;
 
-            On.Celeste.Player.ctor += PlayerInit;
-            On.Celeste.Player.UpdateSprite += UpdatePlayerVisuals;
-            On.Celeste.Player.Update += ZipLine.OnPlayerUpdate;
             On.Celeste.BadelineBoost.Awake += BadelineBoostAwake;
             On.Celeste.ChangeRespawnTrigger.OnEnter += OnChangeRespawn;
         }
@@ -67,15 +62,13 @@ namespace Celeste.Mod.IsaGrabBag {
             DreamSpinnerRenderer.Unload();
             ForceVariants.Unload();
             RewindCrystal.Unload();
+            ZipLine.Unload();
 
             Everest.Events.Level.OnEnter -= Level_OnEnter;
             Everest.Events.Level.OnExit -= Level_OnExit;
             Everest.Events.Level.OnLoadEntity -= Level_OnLoadEntity;
             Everest.Events.Player.OnSpawn -= Player_OnSpawn;
 
-            On.Celeste.Player.ctor -= PlayerInit;
-            On.Celeste.Player.UpdateSprite -= UpdatePlayerVisuals;
-            On.Celeste.Player.Update -= ZipLine.OnPlayerUpdate;
             On.Celeste.BadelineBoost.Awake -= BadelineBoostAwake;
             On.Celeste.ChangeRespawnTrigger.OnEnter -= OnChangeRespawn;
         }
@@ -87,33 +80,10 @@ namespace Celeste.Mod.IsaGrabBag {
             }
         }
 
-        private void UpdatePlayerVisuals(On.Celeste.Player.orig_UpdateSprite orig, Player self) {
-            if (self.StateMachine == ZipLineState) {
-                self.Sprite.Scale.X = Calc.Approach(self.Sprite.Scale.X, 1f, 1.75f * Engine.DeltaTime);
-                self.Sprite.Scale.Y = Calc.Approach(self.Sprite.Scale.Y, 1f, 1.75f * Engine.DeltaTime);
-
-                if (ZipLine.GrabbingCoroutine) {
-                    return;
-                }
-
-                self.Sprite.PlayOffset("fallSlow_carry", .5f, false);
-                self.Sprite.Rate = 0.0f;
-
-            } else {
-                orig(self);
-            }
-        }
-
         private void OnChangeRespawn(On.Celeste.ChangeRespawnTrigger.orig_OnEnter orig, ChangeRespawnTrigger self, Player player) {
             orig(self, player);
 
             ForceVariants.SaveToSession();
-        }
-
-        private void PlayerInit(On.Celeste.Player.orig_ctor orig, Player self, Vector2 position, PlayerSpriteMode spriteMode) {
-            orig(self, position, spriteMode);
-
-            ZipLineState = self.StateMachine.AddState(ZipLine.ZipLineUpdate, begin: ZipLine.ZipLineBegin, end: ZipLine.ZipLineEnd, coroutine: ZipLine.ZipLineCoroutine);
         }
 
         public override void LoadContent(bool firstLoad) {

--- a/Code/Utils.cs
+++ b/Code/Utils.cs
@@ -1,7 +1,35 @@
+using MonoMod.Utils;
+
 namespace Celeste.Mod.IsaGrabBag {
     public static class Utils {
+        public static bool IsGoldenBerryRestart(this Session session) => DynamicData.For(session).Get<bool?>(GrabBagModule.GoldenBerryRestartField) ?? false;
+
         public static float Mod(float x, float m) {
             return ((x % m) + m) % m;
+        }
+
+        public static EntityData GetEntityData(this MapData mapData, string entityName) {
+            foreach (LevelData levelData in mapData.Levels) {
+                if (levelData.GetEntityData(entityName) is EntityData entityData) {
+                    return entityData;
+                }
+            }
+
+            return null;
+        }
+
+        public static bool HasEntity(this MapData mapData, string entityName) {
+            return mapData.GetEntityData(entityName) != null;
+        }
+
+        public static EntityData GetEntityData(this LevelData levelData, string entityName) {
+            foreach (EntityData entity in levelData.Entities) {
+                if (entity.Name == entityName) {
+                    return entity;
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/Code/ZipLine.cs
+++ b/Code/ZipLine.cs
@@ -19,7 +19,6 @@ namespace Celeste.Mod.IsaGrabBag {
         private readonly float height;
         private readonly Sprite sprite;
         private readonly bool usesStamina;
-        private readonly string flag;
         private float speed;
         private bool grabbed;
 
@@ -38,8 +37,6 @@ namespace Celeste.Mod.IsaGrabBag {
             currentGrabbed = null;
             Depth = -500;
 
-            flag = _data.Attr("flag", null)?.Trim();
-
             sprite = GrabBagModule.sprites.Create("zipline");
             sprite.Play("idle");
             sprite.JustifyOrigin(new Vector2(0.5f, 0.25f));
@@ -54,11 +51,6 @@ namespace Celeste.Mod.IsaGrabBag {
             Player self = GrabBagModule.playerInstance;
             self.Ducking = false;
             self.Speed.Y = 0;
-
-            // set flag
-            string flag = currentGrabbed.flag;
-            if (!string.IsNullOrWhiteSpace(flag))
-                self.SceneAs<Level>().Session.SetFlag(flag);
         }
 
         public static void ZipLineEnd() {


### PR DESCRIPTION
- Reverts earlier implementation
- Moves zipline-specific module code into the zipline class (sorry, should have made this a different change lol)
- Sets a global flag in maps with ziplines that is removed if the player transitions after using a zipline (similar to how 1a dashless golden functions)

The "golden berry restart" logic is used to make sure the challenge is still valid after golden deaths, since `Session.StartedFromBeginning` is only true if the golden is placed in the first room in the map (which is the case for 1a)