### PR TITLE
Fix zipline directional issues

### DIFF
--- a/Code/CornerBoostBlock.cs
+++ b/Code/CornerBoostBlock.cs
@@ -104,7 +104,7 @@ namespace Celeste.Mod.IsaGrabBag {
                                 break;
                             }
 
-                            tiles.Tiles[x, y] = tileset.get_Item((int)(u * width), (int)(v * height));
+                            tiles.Tiles[x, y] = tileset[(int)(u * width), (int)(v * height)];
                         }
                     }
                 }

--- a/Code/ZipLine.cs
+++ b/Code/ZipLine.cs
@@ -64,7 +64,7 @@ namespace Celeste.Mod.IsaGrabBag {
             }
 
             if (grabbed) {
-                if (player.Speed.X > 20) {
+                if (Math.Abs(player.Speed.X) > 20) {
                     player.LiftSpeed = player.Speed;
                     player.LiftSpeedGraceTime = 0.2f;
                 }
@@ -187,15 +187,16 @@ namespace Celeste.Mod.IsaGrabBag {
 
             currentGrabbed.speed = self.Speed.X;
 
-            if (Math.Abs(self.LiftSpeed.X) <= Math.Abs(self.Speed.X)) {
+            if (Math.Sign(self.LiftSpeed.X) * Math.Sign(self.Speed.X) == -1 || Math.Abs(self.LiftSpeed.X) <= Math.Abs(self.Speed.X)) {
                 self.LiftSpeed = self.Speed;
                 self.LiftSpeedGraceTime = 0.15f;
             }
 
-            if (Math.Sign(Input.Aim.Value.X) == -Math.Sign(self.Speed.X)) {
-                self.Speed.X = Calc.Approach(self.Speed.X, Input.Aim.Value.X * ZIP_SPEED, ZIP_TURN * Engine.DeltaTime);
-            } else if (Math.Abs(self.Speed.X) <= ZIP_SPEED || Math.Sign(Input.Aim.Value.X) != Math.Sign(self.Speed.X)) {
-                self.Speed.X = Calc.Approach(self.Speed.X, Input.Aim.Value.X * ZIP_SPEED, ZIP_ACCEL * Engine.DeltaTime);
+            int moveX = DynamicData.For(self).Get<int>("moveX");
+            if (Math.Sign(moveX) == -Math.Sign(self.Speed.X)) {
+                self.Speed.X = Calc.Approach(self.Speed.X, moveX * ZIP_SPEED, ZIP_TURN * Engine.DeltaTime);
+            } else if (Math.Abs(self.Speed.X) <= ZIP_SPEED || Math.Sign(moveX) != Math.Sign(self.Speed.X)) {
+                self.Speed.X = Calc.Approach(self.Speed.X, moveX * ZIP_SPEED, ZIP_ACCEL * Engine.DeltaTime);
             }
 
             if (!Input.GrabCheck || self.Stamina <= 0) {


### PR DESCRIPTION
This PR addresses a few issues with ziplines:

- Grabbing a zipline with horizontal speed previously only gave liftspeed when moving right, now it works in both directions. This fixes #9 .
- Reversing direction on a zipline would not start giving liftspeed in the other direction until the absolute value of the previous liftspeed was exceeded. This has been fixed by also comparing the signs of the directions.
- Zipline movement unintentionally used raw analog dash directions, now it uses `moveX`.

(Also stopped calling get_Item directly in CornerBoostBlock to get it to build against latest Everest.)