### PR TITLE
Fix vanilla boosters being broken with Isa's Grab Bag enabled

### DIFF
--- a/.everestignore
+++ b/.everestignore
@@ -1,0 +1,7 @@
+# Files within this mod that should not be loaded by Everest.
+# If you want to add files to this list that will be included in the zip,
+# make sure to also include the .everestignore file in the zip by adding it
+# to the ZippedFiles tag in the .csproj file, or the artifact paths in the
+# Github workflow file if you're using GitHub actions for publishing.
+Code/
+IsaGrabBag.zip

--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,5 @@ MigrationBackup/
 # JetBrains Rider
 .idea
 
+# Mod zip
+IsaGrabBag.zip

--- a/Code/ArrowBubble.cs
+++ b/Code/ArrowBubble.cs
@@ -58,8 +58,8 @@ namespace Celeste.Mod.IsaGrabBag {
         }
 
         private static int Player_RedDashUpdate(On.Celeste.Player.orig_RedDashUpdate orig, Player self) {
-            if (self.CanDash && self.LastBooster != null) {
-                DynamicData boosterData = DynamicData.For(self.LastBooster);
+            if (self.CanDash && self.LastBooster is ArrowBubble arrowBubble) {
+                DynamicData boosterData = DynamicData.For(arrowBubble);
                 boosterData.Set("respawnTimer", 1f);
                 boosterData.Set("cannotUseTimer", 0f);
             }

--- a/Code/ArrowBubble.cs
+++ b/Code/ArrowBubble.cs
@@ -51,14 +51,18 @@ namespace Celeste.Mod.IsaGrabBag {
 
         private static void Player_RedDashEnd(On.Celeste.Player.orig_RedDashEnd orig, Player self) {
             orig(self);
-            if (GravityDir != Vector2.Zero) {
+            
+            if (self.LastBooster is ArrowBubble && GravityDir != Vector2.Zero) {
                 GravityDir = Vector2.Zero;
                 self.UseRefill(twoDashes: false);
             }
         }
 
         private static int Player_RedDashUpdate(On.Celeste.Player.orig_RedDashUpdate orig, Player self) {
-            if (self.CanDash && self.LastBooster is ArrowBubble arrowBubble) {
+            if (self.LastBooster is not ArrowBubble arrowBubble)
+                return orig(self);
+            
+            if (self.CanDash) {
                 DynamicData boosterData = DynamicData.For(arrowBubble);
                 boosterData.Set("respawnTimer", 1f);
                 boosterData.Set("cannotUseTimer", 0f);

--- a/Code/IsaGrabBag.csproj
+++ b/Code/IsaGrabBag.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+    
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <AssemblyName>IsaMods</AssemblyName>
         <RootNamespace>Celeste.Mod.IsaGrabBag</RootNamespace>
         <LangVersion>latest</LangVersion>
         <CelestePrefix Condition="'$(CelestePrefix)' == '' And Exists('..\..\..\Celeste.dll')">..\..\..</CelestePrefix>
         <CelestePrefix Condition="'$(CelestePrefix)' == ''">lib-stripped</CelestePrefix>
+        <ZippedFiles>..\everest.yaml;..\bin\**\*.*;..\Audio\**\*.*;..\Dialog\**\*.*;..\Graphics\**\*.*;..\Ahorn\**\*.*;..\Loenn\**\*.*;..\Effects\**\*.cso</ZippedFiles>
     </PropertyGroup>
 
     <!--Disable "Copy Local" for all references-->
@@ -16,23 +17,87 @@
     </ItemDefinitionGroup>
 
     <ItemGroup>
-        <PackageReference Include="MonoMod.RuntimeDetour" Version="25.0.2" PrivateAssets="all" ExcludeAssets="runtime" />
+        <PackageReference Include="MonoMod.RuntimeDetour" Version="25.3.1" PrivateAssets="all" ExcludeAssets="runtime" />
+        <PackageReference Include="MonoMod.Patcher" Version="25.0.0-prerelease.2" />
+        <PackageReference Include="CelesteAnalyzer" Version="*" />
     </ItemGroup>
 
     <ItemGroup>
-        <Reference Include="$(CelestePrefix)\Celeste.dll" />
-        <Reference Include="$(CelestePrefix)\MMHOOK_Celeste.dll" />
-        <Reference Include="$(CelestePrefix)\FNA.dll" />
+        <PackageReference Include="CelesteMod.Publicizer" Version="*" CelesteAssembly="$(CelestePrefix)\Celeste.dll" />
+        <Reference Include="$(CelestePrefix)\MMHOOK_Celeste.dll" Private="false" />
+        <Reference Include="$(CelestePrefix)\FNA.dll" Private="false" />
     </ItemGroup>
 
-    <Target Name="CopyFiles" AfterTargets="Build">
-        <Copy SourceFiles="$(OutputPath)\$(AssemblyName).dll" DestinationFolder="bin" />
-        <Copy SourceFiles="$(OutputPath)\$(AssemblyName).pdb" DestinationFolder="bin" />
+    <Target Name="CopyFiles" AfterTargets="Build" Inputs="$(OutputPath)\$(AssemblyName).dll;$(OutputPath)\$(AssemblyName).pdb" Outputs="..\bin\$(AssemblyName).dll;..\bin\$(AssemblyName).pdb">
+        <Copy SourceFiles="$(OutputPath)\$(AssemblyName).dll" DestinationFolder="..\bin" />
+        <Copy SourceFiles="$(OutputPath)\$(AssemblyName).pdb" DestinationFolder="..\bin" />
     </Target>
-    
+
+    <Target Name="PackageMod" AfterTargets="CopyFiles" Inputs="$(ZippedFiles)" Outputs="..\IsaGrabBag.zip" Condition="'$(Configuration)' == 'Release'">
+        <ItemGroup>
+            <FilesToPackage Include="$(ZippedFiles)" />
+        </ItemGroup>
+        <PackageMod Files="@(FilesToPackage)" OutputPath="..\IsaGrabBag.zip" />
+    </Target>
+
     <PropertyGroup>
         <PathMap>$(MSBuildProjectDirectory)=IsaGrabBag/</PathMap>
     </PropertyGroup>
+
+    <!-- Inline task used to create a .zip for the mod -->
+    <UsingTask TaskName="PackageMod"
+               TaskFactory="RoslynCodeTaskFactory"
+               AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >
+        <ParameterGroup>
+            <Files ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+            <OutputPath ParameterType="System.String" Required="true" />
+        </ParameterGroup>
+        <Task>
+            <Using Namespace="System.IO" />
+            <Using Namespace="System.IO.Compression" />
+            <Code Type="Fragment" Language="cs">
+                <![CDATA[
+                var projectDir = Path.Combine(@"$(ProjectDir)", ".."); // Go one level up, since we're inside the 'Source' directory
+                projectDir = Uri.UnescapeDataString(projectDir);
+            
+                if (File.Exists(OutputPath))
+                    File.Delete(OutputPath);
+
+                using (ZipArchive zip = ZipFile.Open(OutputPath, ZipArchiveMode.Create))
+                {
+                    foreach (var file in Files)
+                    {
+                        string filePath = file.GetMetadata("FullPath");
+                        string entryName = GetRelativePath(projectDir, filePath);
+                        
+                        zip.CreateEntryFromFile(filePath, entryName);
+                    }
+                }
+    
+                string GetRelativePath(string fromPath, string toPath)
+                {
+                    if (string.IsNullOrEmpty(fromPath)) throw new ArgumentNullException(nameof(fromPath));
+                    if (string.IsNullOrEmpty(toPath))   throw new ArgumentNullException(nameof(toPath));
+                
+                    Uri fromUri = new Uri(fromPath);
+                    Uri toUri = new Uri(toPath);
+                
+                    if (fromUri.Scheme != toUri.Scheme) { return toPath; } // path can't be made relative.
+                
+                    Uri relativeUri = fromUri.MakeRelativeUri(toUri);
+                    string relativePath = Uri.UnescapeDataString(relativeUri.ToString());
+                
+                    if (toUri.Scheme.Equals("file", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        relativePath = relativePath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                    }
+                
+                    return relativePath;
+                }
+            ]]>
+            </Code>
+        </Task>
+    </UsingTask>
     
     <PropertyGroup>
         <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>

--- a/everest.yaml
+++ b/everest.yaml
@@ -1,6 +1,6 @@
 ﻿- Name: IsaGrabBag
   Version: 1.7.3
-  DLL: Code/bin/IsaMods.dll
+  DLL: bin/IsaMods.dll
   Dependencies:
     - Name: EverestCore
       Version: 1.4465.0


### PR DESCRIPTION
When Isa's Grab Bag is enabled, it makes vanilla red boosters unable to reentered before they have respawned, for example by the player being pushed back via a Temple Big Eyeball. Maps such as Creation Through Suffering and little moons from Vanilla Contest rely on this. This PR restores vanilla behaviour and updates the mod to the latest version of the code mod template so it can build properly on newer Everest versions.